### PR TITLE
Part10.3/writing an integrated UI test final update

### DIFF
--- a/app/src/androidTest/java/com/ivy/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/ivy/home/HomeScreenTest.kt
@@ -1,9 +1,14 @@
 package com.ivy.home
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollToNodeAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import com.ivy.common.androidtest.IvyAndroidTest
 import com.ivy.common.androidtest.test_data.saveAccountWithTransactions
 import com.ivy.common.androidtest.test_data.transactionWithTime
@@ -32,6 +37,7 @@ class HomeScreenTest: IvyAndroidTest() {
     fun testSelectingDateRange() = runBlocking<Unit> {
         val date = LocalDate.of(2023, 7, 23)
         setDate(date)
+        refreshPeriod()
 
         val transaction1 = transactionWithTime(Instant.parse("2023-07-24T09:00:00Z")).copy(
             title = "Transaction1"
@@ -51,14 +57,21 @@ class HomeScreenTest: IvyAndroidTest() {
             navigator.navigate(Home.route)
         }
 
-        composeRule.onNodeWithText(date.month.name, ignoreCase = true).performClick()
+        composeRule
+            .onNodeWithText(timeProvider.dateNow().month.name, ignoreCase = true, substring = true)
+            .performClick()
 
         composeRule
-            .onNodeWithText("August")
+            .onNode(horizontalScrollableMatcher())
+            .performScrollToNode(hasText("August"))
+
+        composeRule
+            .onNodeWithText("August", ignoreCase = true)
             .assertIsDisplayed()
             .performClick()
-        composeRule.onNodeWithText("Aug. 01").assertIsDisplayed()
-        composeRule.onNodeWithText("Aug. 31").assertIsDisplayed()
+
+        composeRule.onNodeWithText("Aug. 01",substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Aug. 31",substring = true).assertIsDisplayed()
 
         composeRule.onNodeWithText("Done").performClick()
 
@@ -69,4 +82,6 @@ class HomeScreenTest: IvyAndroidTest() {
         composeRule.onNodeWithText("Transaction3").assertIsDisplayed()
     }
 
+    private fun horizontalScrollableMatcher() =
+        hasScrollToNodeAction() and SemanticsMatcher.keyIsDefined(SemanticsProperties.HorizontalScrollAxisRange)
 }

--- a/buildSrc/src/main/java/com/ivy/buildsrc/IvyPlugin.kt
+++ b/buildSrc/src/main/java/com/ivy/buildsrc/IvyPlugin.kt
@@ -112,6 +112,18 @@ abstract class IvyPlugin : Plugin<Project> {
             compose = true
         }
     }
+    private fun androidTest(project: Project) {
+        project.dependencies {
+            androidTestImplementation("com.willowtreeapps.assertk:assertk:${Versions.assertK}")
+            androidTestImplementation("io.mockk:mockk-android:${Versions.mockk}")
+        }
+        project.configurations.getByName("androidTestImplementation") {
+            exclude(group = "io.mockk", module = "mockk-agent-jvm")
+        }
+        project.androidLibrary().defaultConfig {
+            testInstrumentationRunner = "com.ivy.common.androidtest.HiltTestRunner"
+        }
+    }
 
     private fun setProjectSdkVersions(project: Project) {
         val library = project.androidLibrary()

--- a/buildSrc/src/main/java/com/ivy/buildsrc/IvyPlugin.kt
+++ b/buildSrc/src/main/java/com/ivy/buildsrc/IvyPlugin.kt
@@ -125,18 +125,6 @@ abstract class IvyPlugin : Plugin<Project> {
             compose = true
         }
     }
-    private fun androidTest(project: Project) {
-        project.dependencies {
-            androidTestImplementation("com.willowtreeapps.assertk:assertk:${Versions.assertK}")
-            androidTestImplementation("io.mockk:mockk-android:${Versions.mockk}")
-        }
-        project.configurations.getByName("androidTestImplementation") {
-            exclude(group = "io.mockk", module = "mockk-agent-jvm")
-        }
-        project.androidLibrary().defaultConfig {
-            testInstrumentationRunner = "com.ivy.common.androidtest.HiltTestRunner"
-        }
-    }
 
     private fun setProjectSdkVersions(project: Project) {
         val library = project.androidLibrary()

--- a/common/android-test/src/main/java/com/ivy/common/androidtest/IvyAndroidTest.kt
+++ b/common/android-test/src/main/java/com/ivy/common/androidtest/IvyAndroidTest.kt
@@ -4,11 +4,12 @@ import android.content.Context
 import androidx.datastore.preferences.core.edit
 import androidx.test.core.app.ApplicationProvider
 import com.ivy.common.time.provider.TimeProvider
+import com.ivy.core.domain.action.period.SetSelectedPeriodAct
+import com.ivy.core.domain.pure.time.currentMonthlyPeriod
 import com.ivy.core.persistence.IvyWalletCoreDb
 import com.ivy.core.persistence.datastore.dataStore
 import dagger.hilt.android.testing.HiltAndroidRule
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import java.time.LocalDate
@@ -25,6 +26,9 @@ abstract class IvyAndroidTest {
     @Inject
     lateinit var timeProvider: TimeProvider
 
+    @Inject
+    lateinit var setSelectedPeriodAct: SetSelectedPeriodAct
+
     protected lateinit var context: Context
 
     @Before
@@ -34,10 +38,11 @@ abstract class IvyAndroidTest {
         db.clearAllTables()
         clearDataStore()
     }
+    //After method was removed since Room connection pooler once closed can't be reused.
+    //This change was made on Room 2.6
 
-    @After
-    open fun tearDown() {
-        db.close()
+    private fun clearDataStore() = runBlocking {
+        context.dataStore.edit { it.clear() }
     }
 
     protected fun setDate(date: LocalDate) {
@@ -47,9 +52,11 @@ abstract class IvyAndroidTest {
         }
     }
 
-    private fun clearDataStore() = runBlocking {
-        context.dataStore.edit {
-            it.clear()
-        }
+    protected suspend fun refreshPeriod() {
+        val period = currentMonthlyPeriod(
+            startDayOfMonth = 1,
+            timeProvider = timeProvider
+        )
+        setSelectedPeriodAct(period)
     }
 }

--- a/common/android-test/src/main/java/com/ivy/common/androidtest/IvyAndroidTest.kt
+++ b/common/android-test/src/main/java/com/ivy/common/androidtest/IvyAndroidTest.kt
@@ -39,8 +39,6 @@ abstract class IvyAndroidTest {
         clearDataStore()
     }
     //After method was removed since Room connection pooler once closed can't be reused.
-    //This change was made on Room 2.6
-
     private fun clearDataStore() = runBlocking {
         context.dataStore.edit { it.clear() }
     }
@@ -52,6 +50,7 @@ abstract class IvyAndroidTest {
         }
     }
 
+    //Refresh Ui Composables after setting date for testing
     protected suspend fun refreshPeriod() {
         val period = currentMonthlyPeriod(
             startDayOfMonth = 1,


### PR DESCRIPTION
This pull request improves the reliability and clarity of UI tests for the Home screen by refining date selection logic, enhancing scrolling behavior in Compose tests, and updating test infrastructure to better manage test state and dependencies.

**Test enhancements and scrolling improvements:**

* Updated the Home screen test after update on recent compose versions to use more robust text matching (with `substring = true`) and to scroll horizontally to the "August" month using a custom matcher for horizontal scrollable nodes. This ensures the test works even if the month is not initially visible . [[1]](diffhunk://#diff-364b5e1ad529cb75cdae425e4df0418072b747fc5d694525593144a6dfac8498L54-R74) [[2]](diffhunk://#diff-364b5e1ad529cb75cdae425e4df0418072b747fc5d694525593144a6dfac8498R85-R86)
* Added a `horizontalScrollableMatcher` helper function to identify horizontally scrollable UI elements in Compose tests.

**Test infrastructure and dependency injection:**

* Injected the `SetSelectedPeriodAct` use case into the base test class (`IvyAndroidTest`) to allow programmatic control of the selected period in tests, and added a `refreshPeriod` helper to update UI after changing the date. [[1]](diffhunk://#diff-0bcb017052bee6d747014553e5df387cee70ad59d30e1455242fa784e14c8134R29-R31) [[2]](diffhunk://#diff-0bcb017052bee6d747014553e5df387cee70ad59d30e1455242fa784e14c8134L50-R59)
* Improved test setup by removing the `@After` method that closed the Room database (which caused issues with connection pooling), and ensured the DataStore is cleared before each test run.

**Test reliability improvements:**

* Ensured that the UI is refreshed after setting the date in tests by calling `refreshPeriod`, making tests more deterministic and less dependent on internal state. [[1]](diffhunk://#diff-364b5e1ad529cb75cdae425e4df0418072b747fc5d694525593144a6dfac8498R40) [[2]](diffhunk://#diff-0bcb017052bee6d747014553e5df387cee70ad59d30e1455242fa784e14c8134L50-R59)