### PR TITLE
Part13.1/writing your first end to end test final update

### DIFF
--- a/app/src/androidTest/java/com/ivy/CreateTransactionE2E.kt
+++ b/app/src/androidTest/java/com/ivy/CreateTransactionE2E.kt
@@ -1,13 +1,19 @@
 package com.ivy
 
+import android.content.Context
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.test.core.app.ApplicationProvider
 import com.ivy.common.androidtest.IvyAndroidTest
 import com.ivy.core.data.CategoryType
+import com.ivy.core.persistence.datastore.dataStore
 import com.ivy.home.HomeScreenRobot
 import com.ivy.navigation.Navigator
 import com.ivy.transaction.NewTransactionRobot
 import com.ivy.wallet.ui.RootActivity
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
@@ -18,8 +24,23 @@ class CreateTransactionE2E: IvyAndroidTest() {
     @get:Rule
     val composeRule = createAndroidComposeRule<RootActivity>()
 
+    override fun setUp() {
+        super.setUp()
+        skipOnboarding()
+    }
+
     @Inject
     lateinit var navigator: Navigator
+
+    private fun skipOnboarding() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        runBlocking {
+            val onboardingFinishedKey = booleanPreferencesKey("onboarding_finished")
+            context.dataStore.edit { prefs ->
+                prefs[onboardingFinishedKey] = true
+            }
+        }
+    }
 
     @Test
     fun testCreatingExpenseWithCategoriesAndAccount() {

--- a/app/src/androidTest/java/com/ivy/home/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/com/ivy/home/HomeScreenRobot.kt
@@ -3,10 +3,14 @@ package com.ivy.home
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasAnySibling
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode

--- a/app/src/androidTest/java/com/ivy/home/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/com/ivy/home/HomeScreenRobot.kt
@@ -130,6 +130,11 @@ class HomeScreenRobot(
     }
 
     fun assertTotalExpensesIs(amount: Int): HomeScreenRobot {
+        // Wait for async data to load from database
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag("amount", useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
         composeRule
             .onAllNodesWithTag("amount", useUnmergedTree = true)
             .onLast()

--- a/app/src/androidTest/java/com/ivy/transaction/NewTransactionRobot.kt
+++ b/app/src/androidTest/java/com/ivy/transaction/NewTransactionRobot.kt
@@ -48,6 +48,7 @@ class NewTransactionRobot(
                 }
             }
             .clickAddCategoryOnNewCategoryModal()
+        composeRule.waitForIdle()
         return this
     }
 
@@ -76,7 +77,11 @@ class NewTransactionRobot(
 
     fun chooseSubCategory(parentName: String, subName: String): NewTransactionRobot {
         composeRule.onNodeWithText(parentName).performClick()
-        composeRule.onNodeWithText(subName).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText(subName, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText(subName, useUnmergedTree = true).performClick()
         return this
     }
 

--- a/buildSrc/src/main/java/com/ivy/buildsrc/IvyPlugin.kt
+++ b/buildSrc/src/main/java/com/ivy/buildsrc/IvyPlugin.kt
@@ -112,6 +112,18 @@ abstract class IvyPlugin : Plugin<Project> {
             compose = true
         }
     }
+    private fun androidTest(project: Project) {
+        project.dependencies {
+            androidTestImplementation("com.willowtreeapps.assertk:assertk:${Versions.assertK}")
+            androidTestImplementation("io.mockk:mockk-android:${Versions.mockk}")
+        }
+        project.configurations.getByName("androidTestImplementation") {
+            exclude(group = "io.mockk", module = "mockk-agent-jvm")
+        }
+        project.androidLibrary().defaultConfig {
+            testInstrumentationRunner = "com.ivy.common.androidtest.HiltTestRunner"
+        }
+    }
 
     private fun setProjectSdkVersions(project: Project) {
         val library = project.androidLibrary()

--- a/buildSrc/src/main/java/com/ivy/buildsrc/IvyPlugin.kt
+++ b/buildSrc/src/main/java/com/ivy/buildsrc/IvyPlugin.kt
@@ -125,18 +125,6 @@ abstract class IvyPlugin : Plugin<Project> {
             compose = true
         }
     }
-    private fun androidTest(project: Project) {
-        project.dependencies {
-            androidTestImplementation("com.willowtreeapps.assertk:assertk:${Versions.assertK}")
-            androidTestImplementation("io.mockk:mockk-android:${Versions.mockk}")
-        }
-        project.configurations.getByName("androidTestImplementation") {
-            exclude(group = "io.mockk", module = "mockk-agent-jvm")
-        }
-        project.androidLibrary().defaultConfig {
-            testInstrumentationRunner = "com.ivy.common.androidtest.HiltTestRunner"
-        }
-    }
 
     private fun setProjectSdkVersions(project: Project) {
         val library = project.androidLibrary()


### PR DESCRIPTION
This pull request improves the reliability and consistency of end-to-end UI tests for transaction creation by ensuring onboarding is skipped before tests run and by making UI assertions more robust against asynchronous data loading. The main changes are grouped into test setup improvements and enhancements to UI synchronization in test helpers.

**Test setup improvements:**

* Added logic in `CreateTransactionE2E` to programmatically mark onboarding as finished before each test, ensuring tests start from a consistent state and do not require manual onboarding steps. (`app/src/androidTest/java/com/ivy/CreateTransactionE2E.kt`) [[1]](diffhunk://#diff-c9590e24f604716f4f4be645128f137b06d64600dd5afa4ccc13462cdb6f2905R3-R16) [[2]](diffhunk://#diff-c9590e24f604716f4f4be645128f137b06d64600dd5afa4ccc13462cdb6f2905R27-R44)

**UI synchronization enhancements in test helpers:**

* Updated `HomeScreenRobot.assertTotalExpensesIs` to wait for the expenses data to load from the database before making assertions, reducing flakiness due to asynchronous UI updates. (`app/src/androidTest/java/com/ivy/home/HomeScreenRobot.kt`)
* Improved `NewTransactionRobot.chooseSubCategory` to wait until the subcategory appears in the UI before interacting with it, making the test more reliable. (`app/src/androidTest/java/com/ivy/transaction/NewTransactionRobot.kt`)
* Added a call to `composeRule.waitForIdle()` after adding a new category in `NewTransactionRobot` to ensure the UI is stable before proceeding. (`app/src/androidTest/java/com/ivy/transaction/NewTransactionRobot.kt`)